### PR TITLE
updated fermi to 2.2.0

### DIFF
--- a/heasarc/heasarc6.30.1/Dockerfile
+++ b/heasarc/heasarc6.30.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM sciserver_xmmsas:v6.30.1.4.14.2.0.8.20.0.0
+FROM sciserver_xmmsas:v6.30.1.4.14.2.2.0.20.0.0
 
 ARG heasoft_version=6.30.1
 ARG xmmsas_version=20.0.0

--- a/heasarc/sciserver_fermi/Dockerfile
+++ b/heasarc/sciserver_fermi/Dockerfile
@@ -1,9 +1,9 @@
 FROM sciserver_ciao:v6.30.1.4.14
 
-ARG version=6.30.1.4.14.2.0.8
+ARG version=6.30.1.4.14.2.2.0
 ARG heasoft_version=6.30.1
 ARG ciao_version=4.14
-ARG fermi_version=2.0.8
+ARG fermi_version=2.2.0
 ARG sciserver_user=idies
 ARG pythonenv=fermi
 
@@ -23,7 +23,7 @@ RUN conda create -n $pythonenv python=3 \
 
 ## ------------------------------------ ##
 ## Install the fermitools conda package ##
-RUN mamba install -n $pythonenv -y -c conda-forge -c fermi fermitools python=3 clhep=2.4.4.1 \
+RUN mamba install -n $pythonenv -y -c conda-forge -c fermi fermitools clhep python=3 \ 
  && conda clean -y --all
 
 # .. and fermipy pip

--- a/heasarc/sciserver_fermi/Makefile
+++ b/heasarc/sciserver_fermi/Makefile
@@ -15,7 +15,7 @@
 #=============================================================================#
 
 IMAGE_NAME = sciserver_fermi
-IMAGE_VERSION = 6.30.1.4.14.2.0.8
+IMAGE_VERSION = 6.30.1.4.14.2.2.0
 IMAGE_LABEL = v$(IMAGE_VERSION)
 
 image:

--- a/heasarc/sciserver_xmmsas/Dockerfile
+++ b/heasarc/sciserver_xmmsas/Dockerfile
@@ -1,9 +1,9 @@
-FROM sciserver_fermi:v6.30.1.4.14.2.0.8
+FROM sciserver_fermi:v6.30.1.4.14.2.2.0
 
-ARG version=6.30.1.4.14.2.0.8.20.0.0
+ARG version=6.30.1.4.14.2.2.0.20.0.0
 ARG heasoft_version=6.30.1
 ARG ciao_version=4.14
-ARG fermi_version=2.0.8
+ARG fermi_version=2.2.0
 ARG xmmsas_version=20.0.0
 ARG xmmsas_dir=/opt/xmmsas
 ARG xmmsas_ccfpath=/FTP/caldb/data/xmm/ccf

--- a/heasarc/sciserver_xmmsas/Makefile
+++ b/heasarc/sciserver_xmmsas/Makefile
@@ -15,7 +15,7 @@
 #=============================================================================#
 
 IMAGE_NAME = sciserver_xmmsas
-IMAGE_VERSION = 6.30.1.4.14.2.0.8.20.0.0
+IMAGE_VERSION = 6.30.1.4.14.2.2.0.20.0.0
 IMAGE_LABEL = v$(IMAGE_VERSION)
 
 image:


### PR DESCRIPTION
fermi software was recently updated. The docker image was using the new software but the version number was incorrect, which causes some compiler dependency errors when activating the fermi conda environment.. This update fixes that. remove compiler dependency errors