### PR TITLE
Bug fixes: listen at base path for ping, use relative path for redirect

### DIFF
--- a/compat/cellxgene/nginx.conf
+++ b/compat/cellxgene/nginx.conf
@@ -3,6 +3,12 @@ events {}
 http {
     server {
         listen 0.0.0.0:8888;
+        location <<PREFIX>> {
+            proxy_pass http://127.0.0.1:8080/;
+        }
+        location <<PREFIX>>/ {
+            proxy_pass http://127.0.0.1:8080/;
+        }
         location ~ ^<<PREFIX>>/d/(.*) {
             proxy_set_header Host $host;
             proxy_pass http://127.0.0.1:8080/d/$1;

--- a/compat/cellxgene/starter.py
+++ b/compat/cellxgene/starter.py
@@ -9,7 +9,16 @@ import glob
 app = FastAPI()
 
 port_maps = {'': {'port': 9000, 'proc': 0}}
-timeout = 10
+timeout = 20
+
+def html_msg(msg):
+    return f'''
+    <div
+    id="loadscreen"
+    style="position:absolute;top:0px;left:0px;width:100%;height:100%;border:0px;padding-top: 20%;text-align:center">
+    <div style="font-size:large;"> {msg} </div>
+    </div>
+    '''
 
 def get_annotations_file():
     persistent = glob.glob('/home/idies/workspace/Storage/*/persistent')
@@ -20,46 +29,43 @@ def get_annotations_file():
     return f"{annotations_dir}/sciserver-cellxgene-annotations"
 
 def get_base_url(request):
-    root = request.scope.get('root_path', '')
-    proto = request.headers.get('X-Forwarded-Proto', request.url.scheme)
-    port = request.headers.get('X-Forwarded-Port', 8888)
-    host = request.headers.get('X-Forwarded-Host', request.url.hostname)
-    return f"{proto}://{host}:{port}{root}"
+    return request.scope.get('root_path', '/')
+
+@app.get("/")
+@app.head("/")
+async def root_page():
+    return HTMLResponse(html_msg('cellxgene explorer - no file supplied'))
 
 @app.get("/d/{data:path}")
 async def main_page(request: Request, data: str):
     print('root path is', request.scope.get('root_path'))
     url = f"{get_base_url(request)}/load/{data}"
     return HTMLResponse(f'''
-<html>
-<head>
-<script>
-function cellxgeneload() {{
-  document.getElementById("loadscreen").remove();
-}}
-</script>
-</head>
-<body>
-<iframe
-  onload="cellxgeneload()"
-  style="position: absolute; top:0px; left:0px; width:100%; height:100%; border:0px;"
-  src="{url}">
-</iframe>
-<div
-  id="loadscreen"
-  style="position: absolute; top:0px; left:0px; width:100%; height:100%; border:0px; padding-top: 20%; text-align:center">
-  <div style="font-size:large"> loading cellxgene explorer... </div>
-</div>
-</body>
-</html>
-''', 200)
+    <html>
+    <head>
+    <script>
+    function cellxgeneload() {{
+      document.getElementById("loadscreen").remove();
+    }}
+    </script>
+    </head>
+    <body>
+    <iframe
+      onload="cellxgeneload()"
+      style="position:absolute;top:0px;left:0px;width:100%;height:100%;border:0px;"
+      src="{url}">
+    </iframe>
+    {html_msg("loading cellxgene explorer...")}
+    </body>
+    </html>
+    ''', 200)
 
 @app.get("/load/{data:path}")
 async def redirect_typer(request: Request, data: str):
     if not os.path.exists(data):
         data = f'/{data}'
     if not os.path.exists(data):
-        raise Exception(f'can not find data {data}')
+        return HTMLResponse(html_msg(f'can not find data {data}'), 400)
     print('loading', data)
     port = None
     if data in port_maps:
@@ -68,15 +74,23 @@ async def redirect_typer(request: Request, data: str):
     if not port:
         port = max([i['port'] for i in port_maps.values()]) + 1
         print('starting cellxgene at port', port)
-        p = Popen(['cellxgene', 'launch', '--port', str(port), '--host', '0.0.0.0', '--annotations-file', get_annotations_file(), '-v', data])
+        p = Popen(['cellxgene', 'launch', '--port', str(port), '--host', '0.0.0.0', '--annotations-file',
+                   get_annotations_file(), '-v', data])
         port_maps[data] = {'port': port, 'proc': p}
-        for i in range(timeout):
-            time.sleep(1)
-            try:
-                r = requests.get(f'http://localhost:{port}')
-                if r.status_code == 200:
-                    print('cellxgene started!')
-                    break
-            except:
-                print('waiting on cellxgene')
-    return RedirectResponse(f"{get_base_url(request)}/cellxgene/{port}/")
+    loaded = False
+    for i in range(timeout):
+        time.sleep(1)
+        try:
+            r = requests.get(f'http://localhost:{port}')
+            if r.status_code == 200:
+                print('cellxgene started!')
+                loaded = True
+                break
+        except:
+            print('waiting on cellxgene')
+    if loaded:
+        return RedirectResponse(f"{get_base_url(request)}/cellxgene/{port}/")
+    else:
+        return HTMLResponse(html_msg((
+            '<p>Timed out loading cellxgene explorer. Try reloading page, or check data integrity.</p>'
+            '<p>If you continue to experience problems please contact support<p>')))


### PR DESCRIPTION
And adding some more friendly responses in cases where no data path is given, data file is not found and when the loading times out (which is also increased).

Sorry again about the churn. For this I have deployed these changes both to prod and to a kubernetes based environment and they work as expected.

The main issues:
* The compute PingContianerAction was recv'ing a 404 (for some reason not affecting k8s install). Fixed by adding an explicit proxy rule and a small message at the base path, ensuring the uvicorn server is up in addition to nginx
* In prod, the X-Forwarded-Proto and Port headers were getting comma separated values. Fixed by using relative url in redirect - I'm not sure why I bothered with the full URL forming in the first place.

The fix also comes along with added niceties:
* Show message on basepath
* Increase data loading timeout
* Show message if loading times out, instead of redirecting anyway
* Show message for data file not found (instead of internal server error)