### PR TITLE
Increase timeout on cellxgene loading

### DIFF
--- a/compat/cellxgene/starter.py
+++ b/compat/cellxgene/starter.py
@@ -9,7 +9,7 @@ import glob
 app = FastAPI()
 
 port_maps = {'': {'port': 9000, 'proc': 0}}
-timeout = 20
+timeout = 240
 
 def html_msg(msg):
     return f'''


### PR DESCRIPTION
Big files easily exceed 20 seconds even with no failures. This is not the best solution since feedback to user is lacking, it would be easy to give up prior to the timeout... Mostly that requires fixes in cellxgene itself for faster loading or using the other CXG based single-cell-explorer tool.