### PR TITLE
Update heasoft to 6.32

### DIFF
--- a/heasarc/README.md
+++ b/heasarc/README.md
@@ -26,7 +26,7 @@ This will build parent images. In this case: `sciserver-base`, `sciserver-jupyte
 
 ### Run The Image
 To run the image:
-`docker run --rm -it -p 8888:8888 heasarc -v /data/location/FTP:/home/idies/workspace/headata/FTP /opt/startup.sh`
+`docker run --rm -it -p 8888:8888 -v /data/location/FTP:/home/idies/workspace/headata/FTP heasarc /opt/startup.sh`
 
 where:
 - `-v /data/location/FTP:/home/idies/workspace/headata/FTP` mounts a local `/data/location/FTP` location to `/home/idies/workspace/headata/FTP` inside the container. 
@@ -48,7 +48,7 @@ The tests/ folder contains some simple tests to check the environments have been
 The main different for local testing is the availability of the data. First, run the script in `tests/data/download_data.sh` to download the data needed for testing to `tests/data/FTP`. This FTP folder can then be mounted when running the test:
 
 ```sh
-docker run --rm -it -p 8888:8888 -v $PWD/tests:/home/idies/tests -v ${PWD}/tests/data/FTP/:/home/idies/workspace/headata/FTP  heasarc /opt/test/run_tests.sh
+docker run --rm -it -p 8888:8888 -v $PWD/tests:/home/idies/tests -v ${PWD}/tests/data/FTP/:/home/idies/workspace/headata/FTP  heasarc /home/idies/test/run_tests.sh
 ```
 
 #### Testing on Sciserver

--- a/heasarc/build.json
+++ b/heasarc/build.json
@@ -1,11 +1,11 @@
 {
     "heasoft": {
-        "version": "6.32"
+        "version": "6.32.1"
     },
     
     "ciao": {
         "version": "4.15.1",
-        "heasoft_version": "6.31.1"
+        "heasoft_version": "6.32.1"
     },
     
     "fermi": {

--- a/heasarc/build.json
+++ b/heasarc/build.json
@@ -1,6 +1,6 @@
 {
     "heasoft": {
-        "version": "6.31.1"
+        "version": "6.32"
     },
     
     "ciao": {
@@ -19,7 +19,7 @@
     },
     
     "heasarc": {
-        "version": "0.2",
+        "version": "0.3",
         "NOVNC_VERSION": "1.3.0",
         "DS9_VERSION": "8.4.1"
     },

--- a/heasarc/build.json
+++ b/heasarc/build.json
@@ -25,7 +25,7 @@
     },
     
     "sciserver-jupyter": {
-        "version": "3.0"
+        "version": "3.1"
     },
     
     "sciserver-base": {

--- a/heasarc/ciao/Dockerfile
+++ b/heasarc/ciao/Dockerfile
@@ -6,16 +6,24 @@ ARG headata=/home/idies/workspace/headata/FTP
 ARG user=idies
 ARG pythonenv=ciao
 
+## ------------------------- ##
+## add tools needed for CIAO ##
+USER root
+RUN apt-get update && apt-get -y install \
+    file \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+USER ${user}
+## ------------------------- ##
 
 
 ## ------------------------------ ##
 ## Install the ciao conda package ##
 ## remove xspec modelData and make a link
 USER $user
-# note that numpy=1.24 breaks some tasks, so force 1.23 until ciao fixes it.
 RUN mamba create -n ${pythonenv} -y -c conda-forge \
   -c https://cxc.cfa.harvard.edu/conda/ciao \
-  ciao=${version} sherpa ciao-contrib marx numpy=1.23 \
+  ciao=${version} sherpa ciao-contrib marx python=3.10 \
   \
  && conda clean -y --all \
  && rm -rf /home/$user/miniconda3/pkgs/* \

--- a/heasarc/fermi/Dockerfile
+++ b/heasarc/fermi/Dockerfile
@@ -1,7 +1,6 @@
 FROM ciao:latest
 
 ARG version=2.2.0
-ARG headata=/home/idies/workspace/headata/FTP
 ARG user=idies
 ARG pythonenv=fermi
 

--- a/heasarc/heasarc/Dockerfile
+++ b/heasarc/heasarc/Dockerfile
@@ -8,11 +8,10 @@ ARG pythonenv=heasoft
 ## ----------------------- ##
 ## Install useful software ##
 USER root
+COPY extra_packages.txt .
 RUN apt-get update && apt-get -y install \
-        zip unzip \
-        ghostscript \
-        vim \
-        screen \
+        $(cat extra_packages.txt) \
+ && rm extra_packages.txt \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 ## ----------------------- ##

--- a/heasarc/heasarc/Dockerfile
+++ b/heasarc/heasarc/Dockerfile
@@ -125,7 +125,7 @@ RUN apt-get update && apt-get -y install \
     rm -rf /var/lib/apt/lists/*
     
 ARG NOVNC_VERSION=1.3.0
-RUN wget -q https://github.com/novnc/noVNC/archive/refs/tags/v${NOVNC_VERSION}.tar.gz && \
+RUN curl -L -O https://github.com/novnc/noVNC/archive/refs/tags/v${NOVNC_VERSION}.tar.gz && \
     tar -zxf v${NOVNC_VERSION}.tar.gz && rm v${NOVNC_VERSION}.tar.gz && \
     mv noVNC-${NOVNC_VERSION} /opt/novnc
 

--- a/heasarc/heasarc/Dockerfile
+++ b/heasarc/heasarc/Dockerfile
@@ -36,8 +36,8 @@ RUN bash kernel-additions.sh && \
 
 ## ------------------------ ##
 ## Install WWT labextension ##
-RUN pip install pywwt wwt_kernel_data_relay && \
-    jupyter labextension install @wwtelescope/jupyterlab && \
+RUN mamba run -n ${pythonenv} pip install pywwt wwt_kernel_data_relay && \
+    mamba run -n ${pythonenv} jupyter labextension install @wwtelescope/jupyterlab && \
     pip cache purge
 ## ------------------------ ##
 
@@ -46,7 +46,8 @@ RUN pip install pywwt wwt_kernel_data_relay && \
 ## ------------------------------ ##
 ## Install extra python libraries ##
 ADD requirements.txt requirements.txt
-RUN mamba install -y -c conda-forge --file requirements.txt && mamba clean -y --all && rm requirements.txt \
+RUN mamba install -n ${pythonenv} -y -c conda-forge --file requirements.txt \
+ && mamba clean -y --all && rm requirements.txt \
  && rm -rf /home/$user/miniconda3/pkgs/*
 ## ------------------------------ ##
 
@@ -64,6 +65,14 @@ COPY overrides.json /home/$user/miniconda3/envs/${pythonenv}/share/jupyter/lab/s
 
 # copy out startup.sh to /opt/
 USER root
+
+# fix yarn & clean cache
+RUN apt-get -y remove cmdtest yarn \
+ && npm install -g yarn
+USER $user
+RUN yarn cache clean
+USER root
+
 
 # Copy jupyter-lab startup script
 COPY startup.sh /opt/startup.sh
@@ -92,14 +101,7 @@ USER $user
 # the selection of langing page is done in startup.sh
 RUN cd /home/$user/workspace \
  && git clone https://github.com/HEASARC/sciserver_cookbooks.git \
- && cd sciserver_cookbooks \
- && rm -rf .git
-
-## Fix permissions ##
-USER root
-RUN chown $user:$user -R /opt/heasoft /home/$user
-USER $user
-## --------------- ##
+ && cd sciserver_cookbooks 
 
 # add entry.sh as an entrypoint script, which calls .bashrc before execution; 
 # Needed for running batch jobs.
@@ -138,12 +140,10 @@ ADD ds9/config config
 RUN cd config && bash distribute.sh && cd .. && rm -rf config
 ENV DISPLAY=:1
 
-RUN mamba install -y -c conda-forge websockify supervisor -y && \
-    mamba clean -y --all 
-
-RUN chown -R $user:$user /home/$user
 USER $user
-RUN conda run -n $pythonenv pip install jupyter-server-proxy && \
+RUN mamba install -n $pythonenv -y -c conda-forge websockify supervisor -y && \
+    mamba clean -y --all && \
+    mamba run -n $pythonenv pip install jupyter-server-proxy && \
     pip cache purge
 ## ----------- ##
 
@@ -154,8 +154,8 @@ RUN conda run -n $pythonenv pip install jupyter-server-proxy && \
 ## jupyter_server_terminals | error adding extension (enabled: True): Jupyter Server Terminals requires Jupyter Server 2.0+
 ## The terminal seems to be working fine despite that. Once voila is updated to use jupyter-server=2, this
 ## should disappear
-RUN conda run -n $pythonenv pip install jdaviz && pip cache purge
-RUN jupyter lab build
+RUN conda run -n $pythonenv pip install jdaviz && pip cache purge \
+ && conda run -n $pythonenv jupyter lab build
 ## -------------- ##
 
 # create a script to print the version; the version arg comes from the variable
@@ -165,4 +165,21 @@ User root
 RUN printf "#!/usr/bin/bash\necho HEASARC Sciserver version: $version\necho Build date: `date`" \
     > /usr/local/bin/heasarc-sciserver-version && \
     chmod +x /usr/local/bin/heasarc-sciserver-version
+## Fix permissions ##
+RUN chown $user:$user -R /opt/heasoft /home/$user
+## --------------- ##
 USER $user
+
+
+# change default pip install location so python libraries 
+# installed by the user persist.
+RUN printf "\n\
+if [ -f /home/${user}/workspace/Storage/*/persistent ]; then\n\
+    export PIP_TARGET=/home/${user}/workspace/Storage/*/persistent\n\
+fi\n" >> /home/${user}/.bashrc
+
+# add .bashrc from the user's persistent space
+RUN printf "\n\
+if [ -f /home/${user}/workspace/Storage/*/persistent/.bashrc ]; then\n\
+    . /home/${user}/workspace/Storage/*/persistent/.bashrc\n\
+fi\n" >> /home/${user}/.bashrc

--- a/heasarc/heasarc/Dockerfile
+++ b/heasarc/heasarc/Dockerfile
@@ -27,6 +27,7 @@ WORKDIR /home/$user
 ## ------------------------------ ##
 ## A few additions to the kernels ##
 COPY --chown=$user kernel.json kernel-additions.sh ./
+COPY kernel-run.sh /opt/
 RUN bash kernel-additions.sh && \
     rm kernel.json kernel-additions.sh && \ 
     mamba clean -y --all && rm -rf /home/$user/miniconda3/pkgs/*
@@ -81,13 +82,13 @@ RUN chmod +x /opt/startup.sh
 RUN ln -s $headata /FTP
 
 ## update heasoftpy ##
-ARG SHA=7e410150f6259a3bba894ed25841d33c346076bb
-RUN wget https://github.com/HEASARC/heasoftpy/archive/$SHA.zip \
- && unzip $SHA.zip && rm -f $SHA.zip \
- && cd heasoftpy-$SHA \
- && conda run -n $pythonenv python setup.py build \
- && cp -r build/lib/heasoftpy/* /opt/heasoft/x86_64-*/lib/python/heasoftpy/ \
- && cd .. && rm -rf heasoftpy-$SHA 
+# ARG SHA=7e410150f6259a3bba894ed25841d33c346076bb
+# RUN wget https://github.com/HEASARC/heasoftpy/archive/$SHA.zip \
+#  && unzip $SHA.zip && rm -f $SHA.zip \
+#  && cd heasoftpy-$SHA \
+#  && conda run -n $pythonenv python setup.py build \
+#  && cp -r build/lib/heasoftpy/* /opt/heasoft/x86_64-*/lib/python/heasoftpy/ \
+#  && cd .. && rm -rf heasoftpy-$SHA 
 ## ---------------- ##
 
 
@@ -169,13 +170,6 @@ RUN chown $user:$user -R /opt/heasoft /home/$user
 ## --------------- ##
 USER $user
 
-
-# change default pip install location so python libraries 
-# installed by the user persist.
-RUN printf "\n\
-if [ -f /home/${user}/workspace/Storage/*/persistent ]; then\n\
-    export PIP_TARGET=/home/${user}/workspace/Storage/*/persistent\n\
-fi\n" >> /home/${user}/.bashrc
 
 # add .bashrc from the user's persistent space
 RUN printf "\n\

--- a/heasarc/heasarc/extra_packages.txt
+++ b/heasarc/heasarc/extra_packages.txt
@@ -1,0 +1,6 @@
+zip
+unzip
+ghostscript
+vim
+screen
+rename

--- a/heasarc/heasarc/kernel-additions.sh
+++ b/heasarc/heasarc/kernel-additions.sh
@@ -12,7 +12,7 @@ for env in  heasoft ciao fermi xmmsas; do
     echo "-- Working on conda environment $env --"
 
     # Add conda envs to jupyter
-    mamba install -y -n $env ipykernel jupyterlab=3.5.2 ipywidgets -c conda-forge
+    mamba install -y -n $env ipykernel jupyterlab=3.5.0 ipywidgets -c conda-forge
     mamba run -n $env python -m ipykernel install --user --name=$env --display-name="($env)"
 
     # A fix that ensures notebooks load the scripts in /env/etc/conda/activate.d

--- a/heasarc/heasarc/kernel-run.sh
+++ b/heasarc/heasarc/kernel-run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+env=$1
+file=$2
+
+# ensure the kernel is activated (to load scripts in activate.d) before running a notebook
+. /home/idies/miniconda3/etc/profile.d/conda.sh
+conda activate $env
+python -m ipykernel_launcher -f $file

--- a/heasarc/heasarc/kernel.json
+++ b/heasarc/heasarc/kernel.json
@@ -1,7 +1,6 @@
 {
     "argv": [
-        "conda", "run", "--no-capture-output", "-n", "heasoft", 
-        "python", "-m", "ipykernel_launcher", "-f", "{connection_file}"
+        "bash", "/opt/kernel-run.sh", "heasoft", "{connection_file}"
     ],
     "display_name": "(heasoft)",
     "language": "python",

--- a/heasarc/heasoft/Dockerfile
+++ b/heasarc/heasoft/Dockerfile
@@ -35,8 +35,8 @@ USER ${user}
 ## install heasoftpy dependencies ##
 ## these will need to be done automatically in the future
 COPY requirements.txt .
-RUN conda create -y -n ${pythonenv} python=3.10 --file requirements.txt \
- && conda clean -y --all \
+RUN mamba create -y -n ${pythonenv} python=3.10 --file requirements.txt \
+ && mamba clean -y --all \
  && rm -rf miniconda3/pkgs/* requirements.txt
  
 # needed to get conda to work properly

--- a/heasarc/heasoft/Dockerfile
+++ b/heasarc/heasoft/Dockerfile
@@ -35,14 +35,13 @@ USER ${user}
 ## install heasoftpy dependencies ##
 ## these will need to be done automatically in the future
 COPY requirements.txt .
-RUN conda create -y -n ${pythonenv} python=3.9 --file requirements.txt \
+RUN conda create -y -n ${pythonenv} python=3.10 --file requirements.txt \
  && conda clean -y --all \
  && rm -rf miniconda3/pkgs/* requirements.txt
  
 # needed to get conda to work properly
 ENV BASH_ENV=~/.bashrc
 ENV SHELL=/bin/bash
-RUN echo "source /home/${user}/miniconda3/bin/activate ${pythonenv}" > ~/.bashrc
 SHELL ["/bin/bash", "-c"]
 ## ------------------------------ ##
 
@@ -116,7 +115,7 @@ RUN bash heasoft-setup.sh ${headata} \
  && mkdir -p miniconda3/envs/${pythonenv}/etc/conda/activate.d \
  && mv activate*sh miniconda3/envs/${pythonenv}/etc/conda/activate.d \
  \
- && printf "source activate ${pythonenv}" > ~/.bashrc \
+ && printf "source activate ${pythonenv}" >> ~/.bashrc \
  && printf "source activate ${pythonenv}" >> ~/.cshrc \
  && rm heasoft-setup.sh
 ## ------------------- ##

--- a/heasarc/heasoft/requirements.txt
+++ b/heasarc/heasoft/requirements.txt
@@ -1,2 +1,3 @@
 astropy>=4.0
 scipy>=1.6
+matplotlib

--- a/heasarc/sciserver-jupyter/Dockerfile
+++ b/heasarc/sciserver-jupyter/Dockerfile
@@ -13,14 +13,12 @@ USER idies
 
 WORKDIR /home/idies
 
-RUN curl -L https://repo.anaconda.com/miniconda/Miniconda3-py310_23.3.1-0-Linux-x86_64.sh -o miniconda.sh \
-    && bash miniconda.sh -b \
+RUN curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh -o miniconda.sh \
+    && bash miniconda.sh -b -p /home/idies/miniconda3 \
     && rm -f miniconda.sh \
     && rm -rf /home/idies/miniconda3/pkgs/*
 
 ENV PATH /home/idies/miniconda3/bin:$PATH
-
-RUN conda install -y -c conda-forge mamba=1.4.4
 
 RUN mamba install -y -c conda-forge \
         jupyterlab=3.5.0 \

--- a/heasarc/sciserver-jupyter/Dockerfile
+++ b/heasarc/sciserver-jupyter/Dockerfile
@@ -2,7 +2,7 @@ FROM sciserver-base
 
 EXPOSE 8888
 
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
     && apt-get update \
     && apt-get install -y \
         nodejs \
@@ -13,19 +13,18 @@ USER idies
 
 WORKDIR /home/idies
 
-RUN curl -L https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-Linux-x86_64.sh -o miniconda.sh \
+RUN curl -L https://repo.anaconda.com/miniconda/Miniconda3-py310_23.3.1-0-Linux-x86_64.sh -o miniconda.sh \
     && bash miniconda.sh -b \
     && rm -f miniconda.sh \
     && rm -rf /home/idies/miniconda3/pkgs/*
 
 ENV PATH /home/idies/miniconda3/bin:$PATH
 
-RUN conda install -y -c conda-forge mamba=0.24.0
+RUN conda install -y -c conda-forge mamba=1.4.4
 
 RUN mamba install -y -c conda-forge \
-        jupyter=1.0.0 \
-        jupyterlab=3.4.3 \
-        pip=22.1.2 \
+        jupyterlab=3.5.0 \
+        pip=23.0.1 \
     && conda clean -y --all \
     && jupyter kernelspec remove -f python3 \
     && rm -rf /home/idies/miniconda3/pkgs/*

--- a/heasarc/xmmsas/Dockerfile
+++ b/heasarc/xmmsas/Dockerfile
@@ -46,10 +46,13 @@ RUN wget https://heasarc.gsfc.nasa.gov/FTP/xmm/software/sas/${version}/Linux/Ubu
 
 ## --------------------------- ##
 ## Install python dependencies ##
+RUN printf "\naplpy" >> ${xmmsas_dir}/sas_${version}_python_packages.txt
 USER $user
 WORKDIR /home/$user
 
-RUN conda run -n $pythonenv pip install --no-cache -r ${xmmsas_dir}/sas_${version}_python_packages.txt
+RUN mamba run -n $pythonenv pip install -r ${xmmsas_dir}/sas_${version}_python_packages.txt \
+ && mamba run -n $pythonenv pip cache purge \
+ && rm -r /home/${user}/.cache/pip
 ## --------------------------- ##
 
 
@@ -58,23 +61,32 @@ RUN conda run -n $pythonenv pip install --no-cache -r ${xmmsas_dir}/sas_${versio
 # also, add a script in env/etc/conda/activate.d, so it runs 
 # when the envirenment is activated
 RUN mkdir -p miniconda3/envs/${pythonenv}/etc/conda/activate.d \
+ && mkdir -p miniconda3/envs/${pythonenv}/etc/conda/deactivate.d \
  && printf "\n\
 export SAS_DIR=`ls -d ${xmmsas_dir}/xmmsas_*` \n\
 export SAS_CCFPATH=${ccfpath} \n\
 source \$SAS_DIR/setsas.sh \n\
 if ! [ -d $headata ]; then \n \
-   echo '\\n** HEASARC data Volume is needed for SAS_CCFPATH. Please mounted it when creating the container **\\n' \n\
+   echo '\\n** HEASARC data Volume is needed for SAS_CCFPATH. Please mount it when creating the container **\\n' \n\
 fi \n\
-" > miniconda3/envs/${pythonenv}/etc/conda/activate.d/activate_xmmsas.sh \
+" > miniconda3/envs/${pythonenv}/etc/conda/deactivate.d/activate_xmmsas.sh \
+ && printf "\n\
+export PATH=\$SAS_PREV_PATH \n\
+export LD_LIBRARY_PATH=\$SAS_PREV_LD_LIBRARY_PATH \n\
+" > miniconda3/envs/${pythonenv}/etc/conda/deactivate.d/deactivate_xmmsas.sh \
  \
  && printf "\n\
 setenv SAS_DIR `ls -d ${xmmsas_dir}/xmmsas_*` \n\
 setenv SAS_CCFPATH ${ccfpath} \n\
 source \$SAS_DIR/setsas.csh \n\
 if ! [ -d $headata ]; then \n \
-   echo '\\n** HEASARC data Volume is needed for SAS_CCFPATH. Please mounted it when creating the container **\\n' \n\
+   echo '\\n** HEASARC data Volume is needed for SAS_CCFPATH. Please mount it when creating the container **\\n' \n\
 fi \n\
-" > miniconda3/envs/${pythonenv}/etc/conda/activate.d/activate_xmmsas.csh
+" > miniconda3/envs/${pythonenv}/etc/conda/activate.d/activate_xmmsas.csh \
+ && printf "\n\
+setenv PATH \$SAS_PREV_PATH \n\
+setenv LD_LIBRARY_PATH \$SAS_PREV_LD_LIBRARY_PATH \n\
+" > miniconda3/envs/${pythonenv}/etc/conda/activate.d/deactivate_xmmsas.csh
 ## ------------------- ##
 
 

--- a/heasarc/xmmsas/Dockerfile
+++ b/heasarc/xmmsas/Dockerfile
@@ -69,7 +69,7 @@ source \$SAS_DIR/setsas.sh \n\
 if ! [ -d $headata ]; then \n \
    echo '\\n** HEASARC data Volume is needed for SAS_CCFPATH. Please mount it when creating the container **\\n' \n\
 fi \n\
-" > miniconda3/envs/${pythonenv}/etc/conda/deactivate.d/activate_xmmsas.sh \
+" > miniconda3/envs/${pythonenv}/etc/conda/activate.d/activate_xmmsas.sh \
  && printf "\n\
 export PATH=\$SAS_PREV_PATH \n\
 export LD_LIBRARY_PATH=\$SAS_PREV_LD_LIBRARY_PATH \n\
@@ -86,7 +86,7 @@ fi \n\
  && printf "\n\
 setenv PATH \$SAS_PREV_PATH \n\
 setenv LD_LIBRARY_PATH \$SAS_PREV_LD_LIBRARY_PATH \n\
-" > miniconda3/envs/${pythonenv}/etc/conda/activate.d/deactivate_xmmsas.csh
+" > miniconda3/envs/${pythonenv}/etc/conda/deactivate.d/deactivate_xmmsas.csh
 ## ------------------- ##
 
 


### PR DESCRIPTION
The main change is the installation of `heasoft 6.32`.

Additional minor changes include:
- Install `python==3.10`; `jupyterlab==3.5.0`; `mamba==1.4.4`
- add `file` to ciao, which is a hidden dependency (reported by user).
- add `aplpy` (user request) and deactivation scripts to xmmsas/Dockerfile.
- Add persistent `.bashrc`; and `PIP_TARGET` so the user's pip install persist
- Moved the list of additional tools outside the Dockerfile to `extra_packages.txt` (added `rename`).
- Kept sciserver_cookbooks/.git so users can update the tutorials with `git pull`