### PR TITLE
Fix PATH in the ciao and fermi environments

### DIFF
--- a/heasarc/CHANGES.md
+++ b/heasarc/CHANGES.md
@@ -80,3 +80,6 @@
 ---
 - Update heasoft to 6.36
 - Update the base ubuntu image to 24.02
+
+# Version 0.10.1
+- Fix PATH variable for ciao and fermi environments

--- a/heasarc/build.json
+++ b/heasarc/build.json
@@ -26,7 +26,7 @@
     },
 
     "heasarc": {
-        "version": "0.10",
+        "version": "0.10.1",
         "NOVNC_VERSION": "1.3.0",
         "DS9_VERSION": "8.5"
     },

--- a/heasarc/ciao/Dockerfile
+++ b/heasarc/ciao/Dockerfile
@@ -36,7 +36,9 @@ RUN mamba create -n ${pythonenv} -y -c conda-forge \
  && ln -s ${headata}/caldb /home/${user}/miniforge3/envs/${pythonenv}/CALDB \
  \
  && cd /home/${user}/miniforge3/envs/${pythonenv}/etc/conda/activate.d \
- && cp /home/${user}/miniforge3/envs/heasoft/etc/conda/activate.d/setup_caldb*sh .
+ && cp /home/${user}/miniforge3/envs/heasoft/etc/conda/activate.d/setup_caldb*sh . \
+ # ensure env path takes precedence
+ && echo "export PATH=\$CONDA_PREFIX/bin:\$PATH" > /home/${user}/miniforge3/envs/$pythonenv/etc/conda/activate.d/path-fix.sh
 ## ------------------------------ ##
 
 

--- a/heasarc/fermi/Dockerfile
+++ b/heasarc/fermi/Dockerfile
@@ -22,4 +22,6 @@ WORKDIR /home/$user
 # suppress the warning about these variables being set when activating fermi
 # the name makes it run before other fermi activation scripts 
 RUN printf "unset LD_LIBRARY_PATH\n\
-unset PYTHONPATH" > ./miniforge3/envs/${pythonenv}/etc/conda/activate.d/activate-a.sh
+unset PYTHONPATH" > ./miniforge3/envs/${pythonenv}/etc/conda/activate.d/activate-a.sh \
+ # ensure env path takes precedence
+ && echo "export PATH=\$CONDA_PREFIX/bin:\$PATH" > /home/${user}/miniforge3/envs/$pythonenv/etc/conda/activate.d/path-fix.sh


### PR DESCRIPTION
Ensure the the environment path takes precedence when activating ciao and fermi environments.
A user reports `wavdetect` from ciao does not run correctly because of this.